### PR TITLE
FEUIUX-407 feat: add `no-deprecated-components` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,45 +7,51 @@ const noCyclicModulesImportsConfig = `
 `
 
 module.exports = {
-  extends: [
-    'plugin:eslint-comments/recommended',
-  ],
-  plugins: [
-    'plentific'
-  ],
+  extends: ["plugin:eslint-comments/recommended"],
+  plugins: ["plentific"],
 
   rules: {
-    'eslint-comments/disable-enable-pair': ['error', { allowWholeFile: true }],
-    'eslint-comments/no-unused-disable': 'error',
-    'plentific/debug': 'error',
-    'plentific/no-concurrent-async': 'error',
-    'plentific/no-cyclic-modules-imports': ['error', { config: noCyclicModulesImportsConfig }],
-    'plentific/no-trailing-slash': 'error',
-    'plentific/no-window-location-replace': 'error',
+    "eslint-comments/disable-enable-pair": ["error", { allowWholeFile: true }],
+    "eslint-comments/no-unused-disable": "error",
+    "plentific/debug": "error",
+    "plentific/no-concurrent-async": "error",
+    "plentific/no-deprecated-components": [
+      "error",
+      ["examples/app/components/ComponentDeprecated"],
+    ],
+    "plentific/no-cyclic-modules-imports": [
+      "error",
+      { config: noCyclicModulesImportsConfig },
+    ],
+    "plentific/no-trailing-slash": "error",
+    "plentific/no-window-location-replace": "error",
   },
 
-  overrides: [{
-    files: ['examples/**/*.js{x,}'],
-    parser: '@babel/eslint-parser',
-    parserOptions: {
-      ecmaFeatures: {
-        jsx: true,
-        legacyDecorators: true,
+  overrides: [
+    {
+      files: ["examples/**/*.js{x,}"],
+      parser: "@babel/eslint-parser",
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+          legacyDecorators: true,
+        },
+      },
+      rules: {
+        quotes: [2, "single"],
       },
     },
-    rules: {
-      quotes: [2, 'single']
-    }
-  }, {
-    files: ['examples/**/*.ts{x,}'],
-    parser: '@typescript-eslint/parser',
-    parserOptions: {
-      ecmaFeatures: {
-        jsx: true,
+    {
+      files: ["examples/**/*.ts{x,}"],
+      parser: "@typescript-eslint/parser",
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+        ecmaVersion: 2018,
+        sourceType: "module",
+        project: "./tsconfig.json",
       },
-      ecmaVersion: 2018,
-      sourceType: 'module',
-      project: './tsconfig.json',
     },
-  }]
-}
+  ],
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,10 @@ module.exports = {
     "plentific/no-concurrent-async": "error",
     "plentific/no-deprecated-components": [
       "error",
-      ["examples/app/components/ComponentDeprecated"],
+      {
+        "examples/app/components/ComponentDeprecated":
+          "examples/app/components/Component",
+      },
     ],
     "plentific/no-cyclic-modules-imports": [
       "error",

--- a/examples/app/components/ComponentDeprecated/index.tsx
+++ b/examples/app/components/ComponentDeprecated/index.tsx
@@ -1,0 +1,1 @@
+export const ComponentDeprecated = () => null;

--- a/examples/app/modules/views/ExampleView.tsx
+++ b/examples/app/modules/views/ExampleView.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line plentific/no-deprecated-components
 import { ComponentDeprecated } from "examples/app/components/ComponentDeprecated";
 
 export const ExampleView = () => <ComponentDeprecated />;

--- a/examples/app/modules/views/ExampleView.tsx
+++ b/examples/app/modules/views/ExampleView.tsx
@@ -1,0 +1,3 @@
+import { ComponentDeprecated } from "examples/app/components/ComponentDeprecated";
+
+export const ExampleView = () => <ComponentDeprecated />;

--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 module.exports = {
   rules: {
-    'debug': require('./rules/debug'),
-    'no-concurrent-async': require('./rules/no-concurrent-async'),
-    'no-cyclic-modules-imports': require('./rules/no-cyclic-modules-imports'),
-    'no-trailing-slash': require('./rules/no-trailing-slash'),
-    'no-window-location-replace': require('./rules/no-window-location-replace'),
-  }
-}
+    debug: require("./rules/debug"),
+    "no-concurrent-async": require("./rules/no-concurrent-async"),
+    "no-deprecated-components": require("./rules/no-deprecated-components"),
+    "no-cyclic-modules-imports": require("./rules/no-cyclic-modules-imports"),
+    "no-trailing-slash": require("./rules/no-trailing-slash"),
+    "no-window-location-replace": require("./rules/no-window-location-replace"),
+  },
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-plentific",
-  "version": "1.7.3",
+  "version": "1.8.0",
   "main": "index.js",
   "author": "https://github.com/plentific/",
   "license": "UNLICENSED",

--- a/rules/no-deprecated-components.js
+++ b/rules/no-deprecated-components.js
@@ -1,0 +1,40 @@
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Prevent importing deprecated component based on a configurable list of restricted paths.",
+    },
+    schema: [
+      {
+        type: "array",
+        items: {
+          type: "string",
+        },
+        uniqueItems: true,
+      },
+    ],
+    messages: {
+      deprecatedComponentImport:
+        'Components and utils under "{{path}}" are considered deprecated, please migrate the usage to the agreed upon replacement.',
+    },
+  },
+
+  create(context) {
+    const restrictedPaths = new Set(context.options[0] || []);
+
+    return {
+      ImportDeclaration(node) {
+        if (restrictedPaths.has(node.source.value)) {
+          context.report({
+            node,
+            messageId: "deprecatedComponentImport",
+            data: {
+              path: node.source.value,
+            },
+          });
+        }
+      },
+    };
+  },
+};

--- a/rules/no-deprecated-components.js
+++ b/rules/no-deprecated-components.js
@@ -15,7 +15,7 @@ module.exports = {
     ],
     messages: {
       deprecatedComponentImport:
-        'Components and utils under "{{path}}" are considered deprecated, please migrate the usage to "{{replacement}}".',
+        'Components and utils under "{{path}}" are considered deprecated, please migrate the usage to "{{replacement}}". If this rule is blocking you and you have to disable it, please include a comment with JIRA ticket and the reason for not doing the migration.',
     },
   },
 

--- a/rules/no-deprecated-components.js
+++ b/rules/no-deprecated-components.js
@@ -7,30 +7,30 @@ module.exports = {
     },
     schema: [
       {
-        type: "array",
-        items: {
+        type: "object",
+        additionalProperties: {
           type: "string",
         },
-        uniqueItems: true,
       },
     ],
     messages: {
       deprecatedComponentImport:
-        'Components and utils under "{{path}}" are considered deprecated, please migrate the usage to the agreed upon replacement.',
+        'Components and utils under "{{path}}" are considered deprecated, please migrate the usage to "{{replacement}}".',
     },
   },
 
   create(context) {
-    const restrictedPaths = new Set(context.options[0] || []);
+    const restrictedPaths = context.options[0] || {};
 
     return {
       ImportDeclaration(node) {
-        if (restrictedPaths.has(node.source.value)) {
+        if (restrictedPaths.hasOwnProperty(node.source.value)) {
           context.report({
             node,
             messageId: "deprecatedComponentImport",
             data: {
               path: node.source.value,
+              replacement: restrictedPaths[node.source.value],
             },
           });
         }


### PR DESCRIPTION
## Jira

https://plentific.atlassian.net/browse/FEUIUX-315
https://plentific.atlassian.net/browse/FEUIUX-407

## Description
This is a new rule that will detect imports from paths that were configured as restricted and output a message with a suitable replacement.

Example configuration:
```
'plentific/no-deprecated-components': [
  'error',
  {
    'components/ButtonBlock': 'components/Button',
  },
],
```

## Screenshots
<img width="851" alt="Screenshot 2024-01-31 at 13 09 28" src="https://github.com/plentific/eslint-plugin-plentific/assets/18512701/ad11889e-2705-42b2-b7a6-371fe981482d">
<img width="1161" alt="image" src="https://github.com/plentific/eslint-plugin-plentific/assets/18512701/f6c0c8a2-95bc-419c-a841-3eb2552c7f56">
